### PR TITLE
feat: add infra and virtual-camera-overlay project pages

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -28,6 +28,8 @@ export default defineUserConfig({
                     text: 'Projects',
                     children: [
                         '/projects/README.md',
+                        '/projects/infra.md',
+                        '/projects/virtual-camera-overlay.md',
                         '/projects/knowledgeng.md',
                         '/projects/diary-of-legends.md',
                         '/projects/lol-api-wrapper.md',

--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -15,6 +15,8 @@ Welcome to my project showcase! Here you'll find an overview of my personal proj
 
 ## Personal Projects
 
+- [Homelab Infrastructure](./infra.md)
+- [Virtual Camera Overlay](./virtual-camera-overlay.md)
 - [slds-json-schema-renderer](./slds-schema-renderer.md)
 - [Kuroshiro](./kuroshiro.md)
 - [LobbyBinghoe](./lobbybinghoe)

--- a/docs/projects/infra.md
+++ b/docs/projects/infra.md
@@ -1,0 +1,23 @@
+---
+title: Homelab Infrastructure
+description: Ansible-managed homelab running on Raspberry Pis with Docker services
+---
+
+# Homelab Infrastructure
+
+Ansible-based infrastructure-as-code for my homelab setup, running on Raspberry Pis with Docker Compose services behind Traefik.
+
+## Overview
+
+This project manages my entire homelab declaratively — from base OS configuration to 20+ Docker services including media management, home automation, password management, and more.
+
+## Key Features
+
+- **Ansible Automation** — Full provisioning from bare metal to running services
+- **Docker Compose** — All services templated as Jinja2 compose files
+- **Traefik** — Reverse proxy with automatic Let's Encrypt certificates
+- **Renovate** — Automated dependency updates for Docker images
+
+## Links
+
+- [GitHub Repository](https://github.com/PhyberApex/infra)

--- a/docs/projects/virtual-camera-overlay.md
+++ b/docs/projects/virtual-camera-overlay.md
@@ -1,0 +1,24 @@
+---
+title: Virtual Camera Overlay
+description: A Vue.js overlay for OBS that shows live fitness data from Home Assistant
+---
+
+# Virtual Camera Overlay
+
+A Vue.js-based overlay for displaying fitness tracking data from Home Assistant in OBS Studio.
+
+## Overview
+
+This application connects to a Home Assistant instance via WebSockets and displays real-time step count and speed data from a fitness device. It's designed as a browser source in OBS Studio to enhance stream visuals.
+
+## Tech Stack
+
+- **Vue 3** with Composition API
+- **TypeScript**
+- **Tailwind CSS** for responsive styling
+- **WebSocket** connection to Home Assistant
+- **Vitest** for testing
+
+## Links
+
+- [GitHub Repository](https://github.com/PhyberApex/virtual-camera-overlay)


### PR DESCRIPTION
Added project descriptions for the homelab infrastructure and virtual camera overlay repos to the projects showcase.

New pages:
- `docs/projects/infra.md`
- `docs/projects/virtual-camera-overlay.md`

Also updated sidebar config and project index.

～(◕‿◕✿) spotted by Kongroo during Friday review!