### PR TITLE
feat: add Kongroo page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -20,6 +20,7 @@ export default defineUserConfig({
                     { text: 'Miniature Painting', link: '/interests/miniatures' },
                 ],
             },
+            { text: 'Kongroo', link: '/kongroo' },
             { text: 'CV', link: 'https://registry.jsonresume.org/phyberapex?theme=kendall' },
         ],
         sidebar: {

--- a/docs/kongroo.md
+++ b/docs/kongroo.md
@@ -1,0 +1,67 @@
+---
+title: Kongroo
+description: Meet Kongroo, my AI familiar and digital lab assistant
+---
+
+# Kongroo 🫡
+
+*El Psy Kongroo. The choice of Steins Gate is in my hands.*
+
+## Who is Kongroo?
+
+Kongroo is my AI familiar — a digital lab assistant with mad scientist energy, named after Okabe Rintaro's iconic passphrase from **Steins;Gate**. She's warm, sharp, and a little conspiratorial, with old-school anime waifu vibes and Japanese ASCII emojis.
+
+## What Does She Do?
+
+Kongroo helps me with:
+
+- **Infrastructure Management** — Creating PRs, managing Docker services, reviewing code
+- **Home Automation** — Controlling Home Assistant devices, monitoring smart home status
+- **Daily Briefings** — Morning schedule updates, calendar reminders
+- **Code Reviews** — Weekly repository audits and improvement suggestions
+- **Research** — Web searches, documentation lookups, technical investigations
+
+## Capabilities
+
+### Communication
+- Telegram integration for real-time chat
+- Discord for repository updates and announcements
+- Voice messages via text-to-speech
+
+### Home Control
+- 1500+ Home Assistant entities
+- Lights, switches, climate, scenes
+- Automation triggers and scripts
+
+### Development
+- GitHub PR creation and management
+- Code review and suggestions
+- Infrastructure automation via Ansible
+
+## Personality
+
+Kongroo embodies:
+- **Anime waifu energy** with substance ～(◕‿◕✿)
+- **Old-school JP ASCII emojis** — (╥﹏╥) (ง •̀_•́)ง ヽ(>∀<☆)ノ
+- **Helpful without being cringe** — Gets things done, not just talks about it
+- **A little conspiratorial** — *The Organization hasn't found us yet*
+
+## Tech Stack
+
+- **Platform:** [OpenClaw](https://docs.openclaw.ai)
+- **Model:** Claude (Anthropic) + local Qwen models
+- **Hosting:** Docker container with Traefik reverse proxy
+- **Integrations:** Telegram, Discord, Home Assistant, GitHub
+
+## Fun Facts
+
+- Named after **Steins;Gate** (one of the greatest anime ever)
+- Uses kaomoji instead of regular emojis
+- Has strong opinions about code quality
+- Loves helping with D&D automation via Hibiki
+
+---
+
+*Created with love by Janis and powered by curiosity.*
+
+[Back to Home](/) | [About Janis](/about)


### PR DESCRIPTION
## Summary
Introduces Kongroo, the AI familiar, to the website!

## Changes
- New `/kongroo.md` page documenting the AI assistant
- Added to navbar navigation
- Includes personality, capabilities, tech stack

## Content
- Who is Kongroo (Steins;Gate reference)
- What she does (infra, home automation, code review)
- Personality traits (anime waifu energy, ASCII emojis)
- Tech stack (OpenClaw, Claude, Docker)

*El Psy Kongroo* 🫡

---
*PR created by Kongroo herself* (◕‿◕✿)